### PR TITLE
Support Python 3.6 only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         # Flask) then your app will already have that dependency included, and there's no need to add it here. If you
         # aren't using that particular function, you have no need of the dependency, so we should not install it by
         # default. Only add dependencies here if you introduce a new dependency that exists solely for testing purposes.
+    python_requires="==3.6.*",
     entry_points={
         'console_scripts': [
         ],


### PR DESCRIPTION
Add python_requires specification to setup.py that explicitly declares which versions of Python this library supports/is tested on.

Part of https://trello.com/c/wWFsv1SU/230-be-clear-in-our-libraries-what-versions-of-python-we-support