### PR TITLE
Fix branch name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ name: Create a release
 on:
   push:
     branches:
-      - $default-branch
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Test PR #36 did not cause the release workflow to run, I'm thinking it's because the branch name was `$default-branch` rather than `master`. Let's see if this fixes it...