### PR TITLE
Tweak workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,28 +1,32 @@
 # Upload a Python package to PyPI when a release is created
 #
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# For more information see:
+# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Upload Python package to PyPI
 
 on:
   release:
-    types: [created]
+    types:
+      - published
 
 jobs:
-  deploy:
+  publish:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
+
+    - uses: actions/setup-python@v2
       with:
         python-version: '3.6'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,15 @@
 # If there already exists a tag for the package version number the release
 # should not be created.
 
-name: Create a release
+name: Create a GitHub release
+
 on:
   push:
     branches:
       - master
+
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Change publish workflow match `published` release type rather than `created`. Hopefully this should make the publish workflow run when the release workflow makes a release.

Also:

- Clean up formatting
- Make job names match workflows