### PR TITLE
Fix check if tag exists step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,14 +32,9 @@ jobs:
 
       - name: Check if version tag already exists
         id: version_tag
-        run: |
-          echo -n "::set-output name=exists::"
-          if git rev-parse refs/tags/${{ steps.package_version.outputs.python}} >/dev/null 2>&1
-          then
-            echo "true"
-          else
-            echo "false"
-          fi
+        uses: mukunku/tag-exists-action@f8003af57c02ede2638326be67523df10cf6b10a
+        with:
+          tag: ${{ steps.package_version.outputs.python }}
 
       - name: Create GitHub release
         if: ${{ steps.version_tag.outputs.exists == 'false' }}


### PR DESCRIPTION
Change the step `version_tag` to use an existing third-party action (https://github.com/mukunku/tag-exists-action) instead of shell script.

It turns out that the the checkout action does not include tags (see the output of workflow run [Create a GitHub release #2] which includes debugging information), so the shell script used previously always returns false. The third-party action instead uses the GitHub API to check if the tag exists, which should always work.

For security I've used the commit SHA to tag the specific version of the tag-exists-action and had a brief look through the code.

[Create a GitHub release #2]: https://github.com/alphagov/digitalmarketplace-test-utils/runs/1630511744