### PR TITLE
Change GitHub token used for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ steps.version_tag.outputs.exists == 'false' }}
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DM_GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.package_version.outputs.python }}
           release_name: Release v${{ steps.package_version.outputs.python }}

--- a/dmtestutils/__init__.py
+++ b/dmtestutils/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '2.8.2rc2'
+__version__ = '2.8.2rc3'


### PR DESCRIPTION
Using the automatic GitHub token for releases will mean that other workflows won't be triggered by the release event [[1]].

For our release and publish workflows, we want the publish workflow to be started by the release workflow or by a manual release, so we use a personal access token for the release action.

The personal access token that I've used (added to the repository secrets) is the same as used by Jenkins, so releases will appear as if they were created by Jenkins; if this works though I might go and change the name of the user to be something more generic like `digitalmarketplace-cicd`. Also I will be adding all of this to the manual :D

[1]: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token