### PR TITLE
Switch to run CI against `main`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ name: Create a GitHub release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release:


### PR DESCRIPTION
Trello: https://trello.com/c/16wOFQtJ

We're renaming the 'master' branch following the Github process (https://docs.github.com/en/github/administering-a-repository/renaming-a-branch), but need to update our CI config to match.

Once this is approved, I'll merge and then immediately perform the renaming.