### PR TITLE
Replace make with invoke

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,3 +6,4 @@ max-complexity = 10
 max-line-length = 120
 per-file-ignores =
     **/__init__.py : F401
+    tasks.py: F401

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,11 @@ jobs:
         path: venv
         key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
 
+    - name: Install developer tools
+      run: make bootstrap
+
     - name: Install python dependencies
-      run: make requirements-dev
+      run: invoke requirements-dev
 
     - name: Run python tests
-      run: make test
+      run: invoke test

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,21 @@
-SHELL := /bin/bash
-VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
-.PHONY: virtualenv
-virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
+.DEFAULT_GOAL := bootstrap
 
-.PHONY: requirements-dev
-requirements-dev: virtualenv requirements.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements-dev.txt
+%:
+	-@[ -z "$$TERM" ] || tput setaf 1  # red
+	@>&2 echo warning: calling '`make`' is being deprecated in this repo, you should use '`invoke` (https://pyinvoke.org)' instead.
+	-@[ -z "$$TERM" ] || tput setaf 9  # default
+	@# pass goals to '`invoke`'
+	invoke $(or $(MAKECMDGOALS), $@)
+	@exit
 
-.PHONY: test
-test: show-environment test-flake8 test-python
+help:
+	invoke --list
 
-.PHONY: test-flake8
-test-flake8: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/flake8 .
-
-.PHONY: test-python
-test-python: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
-
-.PHONY: show-environment
-show-environment:
-	@echo "Environment variables in use:"
-	@env | grep DM_ || true
-
+.PHONY: bootstrap
+bootstrap:
+	pip install digitalmarketplace-developer-tools
+	@echo done
+	-@[ -z "$$TERM" ] || tput setaf 2  # green
+	@>&2 echo dmdevtools has been installed globally, run developer tasks with '`invoke`'
+	-@[ -z "$$TERM" ] || tput setaf 9  # default

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,1 @@
+from dmdevtools.invoke_tasks import library_tasks as ns


### PR DESCRIPTION
We want to be able to reduce duplication of code across our repos; one
of the places we have a lot of duplicated code is in our Makefiles; all
of our repos have very similar Makefiles with small historical
differences.

This commit replaces Make with invoke, using the tasks from
alphagov/digitalmarketplace-developer-tools.