### PR TITLE
Add dependabot to this repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "03:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
We've got no production dependencies, so this isn't a big deal. It's good to make sure the dev dependencies that we use for our tests aren't too old, though.